### PR TITLE
Use concurrent hash map for cache in enhanced random

### DIFF
--- a/src/main/java/com/ocadotechnology/gembus/test/EnhancedRandom.java
+++ b/src/main/java/com/ocadotechnology/gembus/test/EnhancedRandom.java
@@ -20,6 +20,7 @@ import org.jeasy.random.EasyRandomParameters;
 import org.jeasy.random.api.Randomizer;
 
 import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
 
@@ -30,7 +31,7 @@ public class EnhancedRandom extends Random {
 
     final EasyRandom easyRandom;
     private final Map<Class<?>, CustomArranger<?>> arrangers;
-    private final HashMap<Set<String>, EasyRandom> cache = new HashMap<>();
+    private final Map<Set<String>, EasyRandom> cache = new ConcurrentHashMap<>();
     private final Supplier<EasyRandomParameters> parametersSupplier;
 
 

--- a/src/test/java/com/ocadotechnology/gembus/bugfix/concurrency/ConcurrencyTest.java
+++ b/src/test/java/com/ocadotechnology/gembus/bugfix/concurrency/ConcurrencyTest.java
@@ -1,0 +1,25 @@
+package com.ocadotechnology.gembus.bugfix.concurrency;
+
+import com.ocadotechnology.gembus.test.Arranger;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+import java.util.UUID;
+import java.util.stream.IntStream;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+public class ConcurrencyTest {
+
+    @Test
+    void concurrentSomeWithOverridesDoesNotThrow() {
+        assertDoesNotThrow(() -> {
+            IntStream.range(0, 10).parallel().mapToObj(i -> createCustomStruct()).toList();
+        });
+    }
+
+    private CustomStruct createCustomStruct() {
+        return Arranger.some(CustomStruct.class, Map.of("id", () -> "id", "uuid", UUID::randomUUID));
+    }
+}
+

--- a/src/test/java/com/ocadotechnology/gembus/bugfix/concurrency/CustomStruct.java
+++ b/src/test/java/com/ocadotechnology/gembus/bugfix/concurrency/CustomStruct.java
@@ -1,0 +1,5 @@
+package com.ocadotechnology.gembus.bugfix.concurrency;
+
+import java.util.UUID;
+
+public record CustomStruct(String id, UUID uuid) {}


### PR DESCRIPTION
See `src/test/java/com/ocadotechnology/gembus/bugfix/concurrency/ConcurrencyTest.java` for example of crashing code.